### PR TITLE
フロントエンドの通信用のエンドポイントの追加

### DIFF
--- a/backend/api/api_v1/api_router.py
+++ b/backend/api/api_v1/api_router.py
@@ -1,9 +1,10 @@
+from api.api_v1.endpoints import closets, clothes, test, users
 from fastapi import APIRouter
-
-from api.api_v1.endpoints import users, closets, clothes
 
 api_router = APIRouter()
 
 api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(closets.router, prefix="/closets", tags=["closets"])
 api_router.include_router(clothes.router, prefix="/clothes", tags=["clothes"])
+
+api_router.include_router(test.router, prefix="/test", tags=["test"])

--- a/backend/api/api_v1/endpoints/test.py
+++ b/backend/api/api_v1/endpoints/test.py
@@ -1,0 +1,12 @@
+import models
+from api import deps
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+router = APIRouter()
+
+
+@router.get("/test")
+async def test(db: Session = Depends(deps.get_db)) -> str:
+    user = db.query(models.User).first()
+    return user.id

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,19 @@
 from api.api_v1.api_router import api_router
 from core.config import settings
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 app = FastAPI(
     title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V1_STR}/openapi.json"
 )
 
+app.add_middleware(
+    CORSMiddleware,
+    expose_headers=["X-Total-Count"],
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=[""],
+)
 
 app.include_router(api_router, prefix=settings.API_V1_STR)


### PR DESCRIPTION
### 概要

`認証不要なテストエンドポイントを追加`

### 説明

#### 概要

このプルリクエストでは、認証が不要なテスト用のエンドポイントを追加します。

#### 詳細

- エンドポイントのパス: `/test`
- 使用するHTTPメソッド: `GET`
- このエンドポイントは、通信テストのために使用されます。

#### この変更が必要な理由

- フロントエンドとの通信テストを容易にするため。
- Firebaseのトークンが不要なので、他のエンドポイントとは異なる点を明確にする。

#### 注意点

🔴 **このエンドポイントはFirebaseのトークンを使用していません。**  
通常の認証フローとは異なりますので、このエンドポイントを使用する際は注意が必要です。