### PR TITLE
ユーザ登録時にデフォルトで1つのクローゼットを作成する

### DIFF
--- a/backend/app/app/api/api_v1/endpoints/users.py
+++ b/backend/app/app/api/api_v1/endpoints/users.py
@@ -1,8 +1,8 @@
-from app import crud
-from app import schemas
-from app.api import deps
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+
+from app import crud, schemas
+from app.api import deps
 
 router = APIRouter()
 
@@ -26,6 +26,11 @@ async def create_user(
 
     user = crud.user.create_with_uid_and_display_name(
         db=db, uid=uid, obj_in=user_in, display_name=display_name
+    )
+
+    # ユーザー作成時に、closetを作成する
+    crud.closet.create_with_uid(
+        db=db, uid=uid, obj_in=schemas.ClosetCreate(name="sample_closet")
     )
 
     return user


### PR DESCRIPTION
### 概要:
ユーザー登録時にクローゼットも自動作成

### 背景:
新規ユーザーが登録された際に、それと同時にクローゼットも自動的に作成されるように機能を追加します。これによって、ユーザーがすぐにアイテムの管理を始められます。

### 変更内容:
`/create` エンドポイントに、新規ユーザーが作成された際にクローゼットも作成するロジックを追加しました。

#### 主な変更点:
- `crud.closet.create_with_uid` 関数を使用して、新規ユーザーが作成された際にクローゼットも作成されるようにしました。
- 作成されるクローゼットの名前はデフォルトで「sample_closet」となります。

```python
# ユーザー作成時に、クローゼットを作成する
crud.closet.create_with_uid(
    db=db, uid=uid, obj_in=schemas.ClosetCreate(name="sample_closet")
)
```

### テスト手順:
1. `/create` エンドポイントを使用して新規ユーザーを作成します。
2. ユーザーが作成された後に、自動的にクローゼットも作成されていることを確認します。